### PR TITLE
separate mod manager logic from gui

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -58,6 +58,7 @@ name = "app"
 version = "0.1.0"
 dependencies = [
  "compress-tools",
+ "dirs",
  "serde",
  "serde_json",
  "tauri",
@@ -592,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +609,17 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.0-rc.9", features = ["api-all"] }
 compress-tools = "0.12.2"
+dirs = "4.0.0"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,14 @@ use compress_tools::*;
 fn main() {
   mod_manager::scan_games();
   tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games, mod_manager::deploy_mod, mod_manager::make_stage_directory])
+    .invoke_handler(tauri::generate_handler![
+      uncompress, 
+      mod_manager::scan_games, 
+      mod_manager::deploy_mod, 
+      mod_manager::make_stage_directory,
+      mod_manager::make_game_stage_directory,
+      mod_manager::get_mods_name
+    ])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,13 +6,13 @@
 mod mod_manager;
 
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path};
 use compress_tools::*;
 
 fn main() {
   mod_manager::scan_games();
   tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![uncompress])
+    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use compress_tools::*;
 fn main() {
   mod_manager::scan_games();
   tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games])
+    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games, mod_manager::deploy_mod])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ use compress_tools::*;
 fn main() {
   mod_manager::scan_games();
   tauri::Builder::default()
-    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games, mod_manager::deploy_mod])
+    .invoke_handler(tauri::generate_handler![uncompress, mod_manager::scan_games, mod_manager::deploy_mod, mod_manager::make_stage_directory])
     .run(tauri::generate_context!())
     .expect("error while running tauri application");
 }

--- a/src-tauri/src/mod_manager.rs
+++ b/src-tauri/src/mod_manager.rs
@@ -1,10 +1,28 @@
-use std::path::PathBuf;
-
+use std::{path::PathBuf};
+use serde::{Deserialize, Serialize};
 use dirs;
 
+#[derive(Serialize, Deserialize)]
+pub struct Game {
+  name: String,
+  path: String,
+}
+#[derive(Serialize, Deserialize)]
+pub struct Mod {
+  path: String,
+}
 #[tauri::command]
-pub(crate) fn scan_games() -> Vec<PathBuf> {
-  let mut steam_games: Vec<PathBuf> = Vec::new();
+pub(crate) fn deploy_mod(mod_: String, deploy: bool) {
+  let mod_u: Mod = serde_json::from_str(&mod_).unwrap();
+  if deploy {
+    println!("Deploy {} to game", mod_u.path);
+  }else {
+    println!("Wont deploy {} to game", mod_u.path);
+  }
+}
+#[tauri::command]
+pub(crate) fn scan_games() -> Vec<String> {
+  let mut steam_games: Vec<String> = Vec::new();
   let home_dir = dirs::home_dir().unwrap();
   let steam_local_dir = home_dir.join(".local/share/Steam/steamapps/common/");
   let steam_flatpak_dir = home_dir.join(".var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/");
@@ -12,8 +30,12 @@ pub(crate) fn scan_games() -> Vec<PathBuf> {
   for dir in steam_dirs {
     if dir.exists() {
       let steam_directories = get_directories(dir);
-      for game in steam_directories {
-        steam_games.push(game);
+      for game_entry in steam_directories {
+        let game_entry_name = game_entry.file_name().unwrap().to_str().unwrap().to_string();
+        let game_entry_path = game_entry.to_str().unwrap().to_string();
+        let game = Game {name: game_entry_name.clone(), path: game_entry_path};
+        let json = serde_json::to_string(&game).unwrap();
+        steam_games.push(json);
       }
     }
   }
@@ -24,8 +46,12 @@ pub(crate) fn scan_games() -> Vec<PathBuf> {
       let mnt_steam_dir = entry.path().join("SteamLibrary/steamapps/common");
       if mnt_steam_dir.exists() {
         let mnt_directories = get_directories(mnt_steam_dir);
-        for game in mnt_directories {
-          steam_games.push(game);
+        for game_entry in mnt_directories {
+          let game_entry_name = game_entry.file_name().unwrap().to_str().unwrap().to_string();
+          let game_entry_path = game_entry.to_str().unwrap().to_string();
+          let game = Game {name: game_entry_name.clone(), path: game_entry_path};
+          let json = serde_json::to_string(&game).unwrap();
+          steam_games.push(json);
         }
       }
     }
@@ -33,7 +59,6 @@ pub(crate) fn scan_games() -> Vec<PathBuf> {
 
   steam_games.into()
 }
-
 fn get_directories(path: PathBuf) -> Vec<PathBuf> {
   let mut directories: Vec<PathBuf> = Vec::new();
   if path.exists() {

--- a/src-tauri/src/mod_manager.rs
+++ b/src-tauri/src/mod_manager.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf};
+use std::{path::PathBuf, fs};
 use serde::{Deserialize, Serialize};
 use dirs;
 
@@ -58,6 +58,15 @@ pub(crate) fn scan_games() -> Vec<String> {
   }
 
   steam_games.into()
+}
+#[tauri::command]
+pub(crate) fn make_stage_directory() {
+  let home_dir = dirs::home_dir().unwrap();
+  let stage_dir = home_dir.join(".config/tmm_stage/games");
+  if !stage_dir.exists() {
+    fs::create_dir(stage_dir).unwrap();
+  }
+  
 }
 fn get_directories(path: PathBuf) -> Vec<PathBuf> {
   let mut directories: Vec<PathBuf> = Vec::new();

--- a/src-tauri/src/mod_manager.rs
+++ b/src-tauri/src/mod_manager.rs
@@ -2,27 +2,36 @@ use std::path::PathBuf;
 
 use dirs;
 
-pub(crate) fn scan_games(){
-
+#[tauri::command]
+pub(crate) fn scan_games() -> Vec<PathBuf> {
+  let mut steam_games: Vec<PathBuf> = Vec::new();
   let home_dir = dirs::home_dir().unwrap();
   let steam_local_dir = home_dir.join(".local/share/Steam/steamapps/common/");
   let steam_flatpak_dir = home_dir.join(".var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/");
   let steam_dirs = [steam_local_dir, steam_flatpak_dir];
   for dir in steam_dirs {
-    let steam_directories = get_directories(dir);
-    println!("{:?}", steam_directories);
-  }
-
-  let mnt_dir = PathBuf::new().join("/mnt/");
-  for entry in mnt_dir.read_dir().unwrap() {
-    if let Ok (entry) = entry {
-      let mnt_steam_dir = entry.path().join("/SteamLibrary/steamapps/common");
-      println!("{}", mnt_steam_dir.display());
-      if mnt_steam_dir.exists() {
-        
+    if dir.exists() {
+      let steam_directories = get_directories(dir);
+      for game in steam_directories {
+        steam_games.push(game);
       }
     }
   }
+
+  let mnt_dir = PathBuf::new().join("/mnt");
+  for entry in mnt_dir.read_dir().unwrap() {
+    if let Ok (entry) = entry {
+      let mnt_steam_dir = entry.path().join("SteamLibrary/steamapps/common");
+      if mnt_steam_dir.exists() {
+        let mnt_directories = get_directories(mnt_steam_dir);
+        for game in mnt_directories {
+          steam_games.push(game);
+        }
+      }
+    }
+  }
+
+  steam_games.into()
 }
 
 fn get_directories(path: PathBuf) -> Vec<PathBuf> {

--- a/src-tauri/src/mod_manager.rs
+++ b/src-tauri/src/mod_manager.rs
@@ -1,4 +1,40 @@
-use std::fs;
+use std::path::PathBuf;
+
+use dirs;
 
 pub(crate) fn scan_games(){
+
+  let home_dir = dirs::home_dir().unwrap();
+  let steam_local_dir = home_dir.join(".local/share/Steam/steamapps/common/");
+  let steam_flatpak_dir = home_dir.join(".var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/");
+  let steam_dirs = [steam_local_dir, steam_flatpak_dir];
+  for dir in steam_dirs {
+    let steam_directories = get_directories(dir);
+    println!("{:?}", steam_directories);
+  }
+
+  let mnt_dir = PathBuf::new().join("/mnt/");
+  for entry in mnt_dir.read_dir().unwrap() {
+    if let Ok (entry) = entry {
+      let mnt_steam_dir = entry.path().join("/SteamLibrary/steamapps/common");
+      println!("{}", mnt_steam_dir.display());
+      if mnt_steam_dir.exists() {
+        
+      }
+    }
+  }
+}
+
+fn get_directories(path: PathBuf) -> Vec<PathBuf> {
+  let mut directories: Vec<PathBuf> = Vec::new();
+  if path.exists() {
+    for entry in path.read_dir().unwrap() {
+      if let Ok (entry) = entry {
+        if entry.path().is_dir() {
+          directories.push(entry.path());
+        }
+      }
+    }
+  }
+  return directories;
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,8 +21,8 @@
                   "$HOME/.local/share/Steam/steamapps/common/*",
                   "$HOME/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/",
                   "$HOME/.var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/*",
-                  "$APP",
-                  "$APP/*"
+                  "$HOME/.config/tmm_stage/",
+                  "$HOME/.config/tmm_stage/*"
                  ]
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script>
 import { fs, path } from '@tauri-apps/api'
 import { ref } from '@vue/reactivity'
+import { invoke } from '@tauri-apps/api/tauri'
 
 import SideBar from './components/SideBar.vue'
 import ModManager from './components/ModManager.vue'
@@ -8,14 +9,7 @@ import ModManager from './components/ModManager.vue'
 import Mixins from './Mixins';
 import supported_games_json from './assets/supported-games.json'
 
-appDirectoryCheck()
-async function appDirectoryCheck() {
-  const appPath = await path.appDir()
-  if(!await Mixins.methods.pathExists(appPath))
-    await fs.createDir(appPath)
-    if(!await Mixins.methods.pathExists(appPath+"games"))
-      await fs.createDir(appPath+"games")
-}
+invoke('make_stage_directory');
 
 export default {
   mixins: [Mixins],

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,4 @@
 <script>
-import { fs, path } from '@tauri-apps/api'
 import { ref } from '@vue/reactivity'
 import { invoke } from '@tauri-apps/api/tauri'
 
@@ -33,17 +32,11 @@ export default {
       if(this.$refs.mod_manager != undefined)
         this.$refs.mod_manager.deployMods()
     },
-    async newGameSelected(gameEntry) {
-      const appDir = await path.appDir()
-      const appGameDir = appDir+"games/"+gameEntry.name
-      this.selected_game = gameEntry
-      if(!await Mixins.methods.pathExists(appGameDir)){
-        fs.createDir(appGameDir)
-        if(!await Mixins.methods.pathExists(appGameDir+"/mods")){
-          fs.createDir(appGameDir+"/mods")
-        }
-      }
-      this.$refs.mod_manager.refreshModList()
+    async newGameSelected(game) {
+      invoke('make_game_stage_directory', {gameName: game.name})
+      this.selected_game = game
+      setTimeout(() => { this.$refs.mod_manager.refreshModList() }, 1);
+
     }
   },
   components: {

--- a/src/Mixins.js
+++ b/src/Mixins.js
@@ -1,4 +1,4 @@
-import { fs,  } from '@tauri-apps/api'
+import { fs } from '@tauri-apps/api'
 
 export default {
   methods: {

--- a/src/components/ModInstaller.vue
+++ b/src/components/ModInstaller.vue
@@ -6,13 +6,13 @@ export default {
   props: ['selected_game'],
   methods: {
     async installMod() {
-      const appDir = await path.appDir()
+      const stageDir = await path.homeDir()+".config/tmm_stage/"
       dialog.open().then((file) => {
         const fileFullName = file.split('/')[file.split('/').length-1]
         const fileExtension = fileFullName.split('.')[fileFullName.split('.').length-1]
         const fileName = fileFullName.split('.')[0]
         if(fileExtension == "zip" || fileExtension == "rar" || fileExtension == "7z"){
-          const appGameDir = appDir+"games/"+this.selected_game.name+"/mods/"+fileName
+          const appGameDir = stageDir+"games/"+this.selected_game.name+"/mods/"+fileName
           invoke('uncompress', { filePath: file, targetPath: appGameDir }).then((result) => {
             this.$emit('on-mod-installed', fileName)
           })

--- a/src/components/ModInstaller.vue
+++ b/src/components/ModInstaller.vue
@@ -1,5 +1,5 @@
 <script>
-import { fs, path, dialog } from '@tauri-apps/api'
+import { path, dialog } from '@tauri-apps/api'
 import { invoke } from '@tauri-apps/api/tauri'
 
 export default {

--- a/src/components/ModManager.vue
+++ b/src/components/ModManager.vue
@@ -1,6 +1,7 @@
 <script>
-import { fs, path } from '@tauri-apps/api'
+import { path } from '@tauri-apps/api'
 import { ref } from '@vue/reactivity'
+import { invoke } from '@tauri-apps/api/tauri'
 
 import Mod from './Mod.vue'
 import ModInstaller from './ModInstaller.vue'
@@ -38,18 +39,18 @@ export default {
         this.mods[modEntry.name] = modEntry
       })
     },
+
     async deployMods(){
       if(this.$refs.mod_ref != undefined){
         const modList = this.$refs.mod_ref
         for(var i=0; i<modList.length; i++){
           const mod = modList[i]
-          if(mod.$refs.mod_enabled.checked)
-            this.copyDir(mod.tmm_mod_path, this.selected_game.path+supported_games_json[this.selected_game.name].extensionsPath['**'])
-          else
-            this.removeMod(mod.tmm_mod_path, this.selected_game.path+supported_games_json[this.selected_game.name].extensionsPath['**'])
+          const json = {path: mod.tmm_mod_path}      
+          invoke('deploy_mod', { mod: JSON.stringify(json), deploy: mod.$refs.mod_enabled.checked })
         }
       }
     },
+
     async copyDir(from_path, to_path){
       const fromDir = await fs.readDir(from_path)
       for(var i=0; i<fromDir.length; i++){
@@ -64,6 +65,7 @@ export default {
         }
       }
     },
+
     async removeMod(tmm_path, game_path){
       const modDir = await fs.readDir(tmm_path)
       for(var i=0; i<modDir.length; i++){

--- a/src/components/ModManager.vue
+++ b/src/components/ModManager.vue
@@ -1,6 +1,7 @@
 <script>
 import { ref } from '@vue/reactivity'
-import { invoke } from '@tauri-apps/api/tauri'
+import { invoke, dialog } from '@tauri-apps/api/tauri'
+//import { fs } from '@tauri-apps/api'
 
 import Mod from './Mod.vue'
 import ModInstaller from './ModInstaller.vue'
@@ -32,7 +33,6 @@ export default {
     async refreshModList(){
       this.resetMods()
       const modsEntrys = await invoke('get_mods_name', {gameName: this.selected_game.name})
-      console.log(modsEntrys)
       modsEntrys.forEach(modEntry => {
         const modJson = JSON.parse(modEntry)
         this.mods[modJson.name] = modJson
@@ -44,8 +44,16 @@ export default {
         const modList = this.$refs.mod_ref
         for(var i=0; i<modList.length; i++){
           const mod = modList[i]
-          const json = {path: mod.tmm_mod_path}      
+          const json = {name: mod.mod_name, path: mod.tmm_mod_path}      
           invoke('deploy_mod', { mod: JSON.stringify(json), deploy: mod.$refs.mod_enabled.checked })
+          //
+          // Deploying mods needs to be rewrittin in rust, with VFS until then nothing.
+          //
+          /*if(mod.$refs.mod_enabled.checked){
+            this.copyDir(mod.tmm_mod_path, this.selected_game.path+supported_games_json[this.selected_game.name].extensionsPath['**'])
+          }else{
+            this.removeMod(mod.tmm_mod_path, this.selected_game.path+supported_games_json[this.selected_game.name].extensionsPath['**'])
+          }*/
         }
       }
     },

--- a/src/components/ModManager.vue
+++ b/src/components/ModManager.vue
@@ -1,5 +1,4 @@
 <script>
-import { path } from '@tauri-apps/api'
 import { ref } from '@vue/reactivity'
 import { invoke } from '@tauri-apps/api/tauri'
 
@@ -32,11 +31,11 @@ export default {
   methods: {
     async refreshModList(){
       this.resetMods()
-      const appPath = await path.appDir()
-      const selectedGamePath = appPath+"games/"+this.selected_game.name+"/mods/"
-      const selectedGameModsEntrys = await Mixins.methods.getDirectorysFromPath(selectedGamePath)
-      selectedGameModsEntrys.forEach(modEntry => {
-        this.mods[modEntry.name] = modEntry
+      const modsEntrys = await invoke('get_mods_name', {gameName: this.selected_game.name})
+      console.log(modsEntrys)
+      modsEntrys.forEach(modEntry => {
+        const modJson = JSON.parse(modEntry)
+        this.mods[modJson.name] = modJson
       })
     },
 
@@ -51,7 +50,7 @@ export default {
       }
     },
 
-    async copyDir(from_path, to_path){
+    /*async copyDir(from_path, to_path){
       const fromDir = await fs.readDir(from_path)
       for(var i=0; i<fromDir.length; i++){
         const file = fromDir[i]
@@ -77,7 +76,7 @@ export default {
           }
         }
       }
-    }
+    }*/
   }
 }
 </script>

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -36,7 +36,7 @@ export default {
 
     selectNewGame(e, gameEntry){
       const gameButton = e.target 
-      const buttonList = this.$el.querySelectorAll('.game-list li button')
+      const buttonList = this.$refs.game_ref
       buttonList.forEach(elem => {
         elem.className = ""
       })
@@ -52,7 +52,7 @@ export default {
   <button class="scan-games-button" @click="scanGames()">Scan games</button>
   <div class="game-list">
     <li v-for="(game) in games" :key="game">
-      <button @click="selectNewGame($event, game)">{{ game.name }}</button>
+      <button ref="game_ref" @click="selectNewGame($event, game)">{{ game.name }}</button>
     </li>
   </div>
   <div class="options-bottom">

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,6 +1,7 @@
 <script>
 import { fs, path } from '@tauri-apps/api'
 import { reactive } from '@vue/reactivity'
+import { invoke } from '@tauri-apps/api/tauri'
 
 import Mixins from '../Mixins';
 import supported_games_json from '../assets/supported-games.json'

--- a/src/components/SideBar.vue
+++ b/src/components/SideBar.vue
@@ -1,5 +1,4 @@
 <script>
-import { fs, path } from '@tauri-apps/api'
 import { reactive } from '@vue/reactivity'
 import { invoke } from '@tauri-apps/api/tauri'
 
@@ -19,39 +18,22 @@ export default {
   },
   methods: {
     async scanGames() {
-      let steamGamesEntry = []
-      const homeDir = await path.homeDir()
-      const steamLocalPath = homeDir+".local/share/Steam/steamapps/common/"
-      const steamFlatpakPath = homeDir+".var/app/com.valvesoftware.Steam/data/Steam/steamapps/common/"
-      const steamPaths = [steamLocalPath,steamFlatpakPath]
-      for(var i=0; i<steamPaths.length; i++){
-        if(await Mixins.methods.pathExists(steamPaths[i])){
-          const localSteamPath = steamPaths[i]
-          const localGameEntrys = await Mixins.methods.getDirectorysFromPath(localSteamPath)
-          steamGamesEntry = steamGamesEntry.concat(localGameEntrys)
-        }
-      }
-
-      const mntDir = await fs.readDir('/mnt/')
-      for(var i=0; i<mntDir.length; i++){
-        const mntSteamPath = mntDir[i].path+'/SteamLibrary/steamapps/common'
-        if(await Mixins.methods.pathExists(mntSteamPath)){
-          const mntGameEntrys = await Mixins.methods.getDirectorysFromPath(mntSteamPath)
-          steamGamesEntry = steamGamesEntry.concat(mntGameEntrys)
-        }
-      }
-
-      steamGamesEntry.forEach(entry => {
-        if(this.supported_games[entry.name]){
-          this.games[entry.name] = entry
-        }
+      await invoke('scan_games').then((entrys) => {
+        entrys.forEach(element => {
+          let game = JSON.parse(element)
+          if(this.supported_games[game.name]){
+            this.games[game.name] = game
+          }
+        })
       })
+
       this.$emit('on-scan-games')
     },
 
     sendDeployMods() {
       this.$emit('deploying-mods')
     },
+
     selectNewGame(e, gameEntry){
       const gameButton = e.target 
       const buttonList = this.$el.querySelectorAll('.game-list li button')
@@ -74,7 +56,7 @@ export default {
     </li>
   </div>
   <div class="options-bottom">
-    <button class="settings-button">···</button>
+    <button class="run-button">Run</button>
     <button class="deploy-button" @click="sendDeployMods()">Deploy</button>
   </div>
   <div class="separator-right"></div>
@@ -141,12 +123,9 @@ export default {
 .options-bottom i {
   font-size: 16px;
 }
-.settings-button {
-  width: 35px;
-}
 .deploy-button {
   width: 115px;
-  margin-left: 25px;
+  margin-left: 14px;
   margin-right: 20px;
 }
 .separator-right {


### PR DESCRIPTION
Added mod_manager.rs and moved scanGames and deployMods to rust instead.

Deploy will no longer do anything as i will be working on the VFS logic where instead of actually putting the mods into the games folder, it will create a seperate folder for the game and will overlay the mods on top of it, this way the game folder is never actually changed and always stays like it is when downloaded. this will not only make it easier to mod your game but also prevent modding from breaking your game install.